### PR TITLE
Refactor encoding query args

### DIFF
--- a/encode.ts
+++ b/encode.ts
@@ -9,8 +9,7 @@ function toPostgresArray(array: Array<any>): string {
         if (!element) {
             postgresArray += "NULL";
         } else {
-            // TODO: handles only primitive types
-            postgresArray += element.toString();
+            postgresArray += encode(element);
         }
     })
 

--- a/encode.ts
+++ b/encode.ts
@@ -1,0 +1,37 @@
+function toPostgresArray(array: Array<any>): string {
+    let postgresArray = "{";
+
+    array.forEach((element, index) => {
+        if (index > 0) {
+            postgresArray += ",";
+        }
+
+        if (!element) {
+            postgresArray += "NULL";
+        } else {
+            // TODO: handles only primitive types
+            postgresArray += element.toString();
+        }
+    })
+
+    postgresArray += "}";
+    return postgresArray;
+}
+
+export type EncodedArg = null | string | Uint8Array;
+
+export function encode(value: any): EncodedArg {
+    if (value === null || typeof value === "undefined") {
+        return null;
+    } else if (value instanceof Uint8Array) {
+        return value;
+    } else if (value instanceof Date) {
+        return value.toISOString();
+    } else if (value instanceof Array) {
+        return toPostgresArray(value);
+    } else if (value instanceof Object) {
+        return JSON.stringify(value);
+    } else {
+        return value.toString();
+    }
+}

--- a/encode.ts
+++ b/encode.ts
@@ -1,10 +1,3 @@
-function escapeValue(value: string): string {
-    value = value.toString();
-    const escapedValue = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-
-    return `"${escapedValue}"`;
-}
-
 function pad(number: number, digits: number): string {
     let padded = "" + number
     while (padded.length < digits) { 
@@ -46,29 +39,36 @@ function encodeDate(date: Date): string {
     return encodedDate + encodedTz; 
 }
 
+function escapeArrayElement(value: string): string {
+    value = value.toString();
+    const escapedValue = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+    return `"${escapedValue}"`;
+}
+
 function encodeArray(array: Array<any>): string {
-    let postgresArray = "{";
+    let encodedArray = "{";
 
     array.forEach((element, index) => {
         if (index > 0) {
-            postgresArray += ",";
+            encodedArray += ",";
         }
 
         if (element === null || typeof element === "undefined") {
-            postgresArray += "NULL";
+            encodedArray += "NULL";
         } else if (Array.isArray(element)) {
-            postgresArray += encodeArray(element);
+            encodedArray += encodeArray(element);
         } else if (element instanceof Uint8Array) {
             // TODO: it should be encoded as bytea?
             throw new Error("Can't encode array of buffers.");
         } else {
             const encodedElement = encode(element);
-            postgresArray += escapeValue(encodedElement as string);
+            encodedArray += escapeArrayElement(encodedElement as string);
         }
     })
 
-    postgresArray += "}";
-    return postgresArray;
+    encodedArray += "}";
+    return encodedArray;
 }
 
 export type EncodedArg = null | string | Uint8Array;

--- a/encode.ts
+++ b/encode.ts
@@ -1,4 +1,52 @@
-function toPostgresArray(array: Array<any>): string {
+function escapeValue(value: string): string {
+    value = value.toString();
+    const escapedValue = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+    return `"${escapedValue}"`;
+}
+
+function pad(number: number, digits: number): string {
+    let padded = "" + number
+    while (padded.length < digits) { 
+        padded = "0" + padded;
+    }
+    return padded;
+}
+
+function encodeDate(date: Date): string {
+    // Construct ISO date
+    const year = pad(date.getFullYear(), 4);
+    const month = pad(date.getMonth() + 1, 2);
+    const day = pad(date.getDate(), 2);
+    const hour = pad(date.getHours(), 2);
+    const min = pad(date.getMinutes(), 2);
+    const sec = pad(date.getSeconds(), 2);
+    const ms = pad(date.getMilliseconds(), 3);
+
+    const encodedDate = `${year}-${month}-${day}T${hour}:${min}:${sec}.${ms}`;
+
+    // Construct timezone info
+    // 
+    // Date.prototype.getTimezoneOffset();
+    // 
+    // From MDN:
+    // > The time-zone offset is the difference, in minutes, from local time to UTC. 
+    // > Note that this means that the offset is positive if the local timezone is 
+    // > behind UTC and negative if it is ahead. For example, for time zone UTC+10:00
+    // > (Australian Eastern Standard Time, Vladivostok Time, Chamorro Standard Time), 
+    // > -600 will be returned.
+    const offset = date.getTimezoneOffset();
+    const tzSign = offset > 0 ? '-' : '+';
+    const absOffset = Math.abs(offset);
+    const tzHours = pad(Math.floor(absOffset / 60), 2);
+    const tzMinutes = pad(Math.floor(absOffset % 60), 2);
+
+    const encodedTz = `${tzSign}${tzHours}:${tzMinutes}`;
+
+    return encodedDate + encodedTz; 
+}
+
+function encodeArray(array: Array<any>): string {
     let postgresArray = "{";
 
     array.forEach((element, index) => {
@@ -6,10 +54,16 @@ function toPostgresArray(array: Array<any>): string {
             postgresArray += ",";
         }
 
-        if (!element) {
+        if (element === null || typeof element === "undefined") {
             postgresArray += "NULL";
+        } else if (Array.isArray(element)) {
+            postgresArray += encodeArray(element);
+        } else if (element instanceof Uint8Array) {
+            // TODO: it should be encoded as bytea?
+            throw new Error("Can't encode array of buffers.");
         } else {
-            postgresArray += encode(element);
+            const encodedElement = encode(element);
+            postgresArray += escapeValue(encodedElement as string);
         }
     })
 
@@ -25,9 +79,9 @@ export function encode(value: any): EncodedArg {
     } else if (value instanceof Uint8Array) {
         return value;
     } else if (value instanceof Date) {
-        return value.toISOString();
+        return encodeDate(value);
     } else if (value instanceof Array) {
-        return toPostgresArray(value);
+        return encodeArray(value);
     } else if (value instanceof Object) {
         return JSON.stringify(value);
     } else {

--- a/tests/encode.ts
+++ b/tests/encode.ts
@@ -1,0 +1,92 @@
+import { test, assertEqual } from "https://deno.land/x/std@v0.2.6/testing/mod.ts";
+import { encode } from "../encode.ts";
+
+// internally `encode` uses `getTimezoneOffset` to encode Date
+// so for testing purposes we'll be overriding it
+const _getTimezoneOffset = Date.prototype.getTimezoneOffset
+
+function resetTimezoneOffset() {
+    Date.prototype.getTimezoneOffset = _getTimezoneOffset
+}
+
+function overrideTimezoneOffset(offset: number) {
+    Date.prototype.getTimezoneOffset = function () { return offset }
+}
+
+test(function encodeDatetime() {
+    // GMT
+    overrideTimezoneOffset(0);
+
+    const gmtDate = new Date(2019, 1, 10, 20, 30, 40, 5);
+    const gmtEncoded = encode(gmtDate);
+    assertEqual(gmtEncoded, "2019-02-10T20:30:40.005+00:00");
+
+    resetTimezoneOffset();
+
+    // GMT+02:30
+    overrideTimezoneOffset(-150);
+
+    const date = new Date(2019, 1, 10, 20, 30, 40, 5);
+    const encoded = encode(date);
+    assertEqual(encoded, "2019-02-10T20:30:40.005+02:30");
+
+    resetTimezoneOffset();
+})
+
+test(function encodeUndefined() {
+    assertEqual(encode(undefined), null);
+});
+
+test(function encodeNull() {
+    assertEqual(encode(null), null);
+})
+
+test(function encodeBoolean() {
+    assertEqual(encode(true), "true");
+    assertEqual(encode(false), "false");
+})
+
+test(function encodeNumber() {
+    assertEqual(encode(1), "1");
+    assertEqual(encode(1.2345), "1.2345");
+});
+
+test(function encodeString() {
+    assertEqual(encode("deno-postgres"), "deno-postgres");
+});
+
+test(function encodeObject() {
+    assertEqual(encode({ x: 1 }), '{"x":1}');
+});
+
+test(function encodeUint8Array() {
+    const buf = new Uint8Array([1, 2, 3]);
+    const encoded = encode(buf);
+
+    assertEqual(buf, encoded);
+});
+
+test(function encodeArray() {
+    const array = [null, "postgres", 1, ["foo", "bar"]];
+    const encodedArray = encode(array);
+
+    assertEqual(encodedArray, '{NULL,"postgres","1",{"foo","bar"}}');
+});
+
+test(function encodeObjectArray() {
+    const array = [{ x: 1 }, { y: 2 }];
+    const encodedArray = encode(array);
+    assertEqual(encodedArray, '{"{\\"x\\":1}","{\\"y\\":2}"}');
+});
+
+test(function encodeDateArray() {
+    overrideTimezoneOffset(0);
+
+    const array = [
+        new Date(2019, 1, 10, 20, 30, 40, 5)
+    ];
+    const encodedArray = encode(array);
+    assertEqual(encodedArray, '{"2019-02-10T20:30:40.005+00:00"}');
+
+    resetTimezoneOffset();
+});

--- a/utils.ts
+++ b/utils.ts
@@ -30,26 +30,6 @@ export function readUInt32BE(buffer: Uint8Array, offset: number): number {
         )
 }
 
-export function toPostgresArray(array: Array<any>): string {
-    let postgresArray = "{";
-
-    array.forEach((element, index) => {
-        if (index > 0) {
-            postgresArray += ",";
-        }
-
-        if (!element) {
-            postgresArray += "NULL";
-        } else {
-            // TODO: handles only primitive types
-            postgresArray += element.toString();
-        }
-    })
-
-    postgresArray += "}";
-    return postgresArray;
-}
-
 export interface DsnResult {
     driver: string;
     user: string;


### PR DESCRIPTION
Closes #13 

Moved logic of encoding JS types to `encode.ts`.

Also added `encoder` argument to `QueryConfig` - this will allow users to extend this lib capabilities for custom types. 