### PR TITLE
Refactor query and pool tests to use a shared setup

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -1,4 +1,3 @@
-import { dial } from "deno";
 import { Connection } from "./connection.ts";
 import { Pool } from "./pool.ts";
 import { Query, QueryConfig, QueryResult } from "./query.ts";
@@ -14,12 +13,7 @@ export class Client {
   }
 
   async connect(): Promise<void> {
-    const { host, port } = this._connectionParams;
-    let addr = `${host}:${port}`;
-
-    const conn = await dial("tcp", addr);
-    this._connection = new Connection(conn, this._connectionParams);
-
+    this._connection = new Connection(this._connectionParams);
     await this._connection.startup();
     await this._connection.initSQL();
   }

--- a/connection.ts
+++ b/connection.ts
@@ -26,7 +26,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Conn } from "deno";
+import { Conn, dial } from "deno";
 import { BufReader, BufWriter } from "https://deno.land/x/io/bufio.ts";
 import { PacketWriter } from "./packet_writer.ts";
 import { readUInt32BE } from "./utils.ts";
@@ -75,6 +75,8 @@ export class RowDescription {
 }
 
 export class Connection {
+  private conn: Conn;
+
   private bufReader: BufReader;
   private bufWriter: BufWriter;
   private packetWriter: PacketWriter;
@@ -86,11 +88,7 @@ export class Connection {
   private _secretKey?: number;
   private _parameters: { [key: string]: string } = {};
 
-  constructor(private conn: Conn, private connParams: ConnectionParams) {
-    this.bufReader = new BufReader(conn);
-    this.bufWriter = new BufWriter(conn);
-    this.packetWriter = new PacketWriter();
-  }
+  constructor(private connParams: ConnectionParams) {}
 
   /** Read single message sent by backend */
   async readMessage(): Promise<Message> {
@@ -136,6 +134,14 @@ export class Connection {
   }
 
   async startup() {
+    const { host, port } = this.connParams;
+    let addr = `${host}:${port}`;
+    this.conn = await dial("tcp", addr);
+
+    this.bufReader = new BufReader(this.conn);
+    this.bufWriter = new BufWriter(this.conn);
+    this.packetWriter = new PacketWriter();
+
     await this._sendStartupMessage();
     await this.bufWriter.flush();
 
@@ -562,9 +568,10 @@ export class Connection {
   }
 
   async initSQL(): Promise<void> {
+    // validate the connection using a
     const config: QueryConfig = { text: "select 1;", args: [] };
     const query = new Query(config);
-    await query.execute(this);
+    await this.query(query);
   }
 
   async end(): Promise<void> {
@@ -572,5 +579,9 @@ export class Connection {
     await this.bufWriter.write(terminationMessage);
     await this.bufWriter.flush();
     this.conn.close();
+    delete this.conn;
+    delete this.bufReader;
+    delete this.bufWriter;
+    delete this.packetWriter;
   }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -3,7 +3,8 @@ export { copyBytes } from "https://deno.land/x/std@v0.2.8/io/util.ts";
 export {
   test,
   assertEqual,
-  runTests
+  runTests,
+  TestFunction
 } from "https://deno.land/x/std@v0.2.8/testing/mod.ts";
 
 export {

--- a/pool.ts
+++ b/pool.ts
@@ -1,4 +1,3 @@
-import { dial } from "deno";
 import { Client, PooledClient } from "./client.ts";
 import { Connection } from "./connection.ts";
 import { ConnectionParams, IConnectionParams } from "./connection_params.ts";
@@ -19,12 +18,7 @@ export class Pool {
   }
 
   private async newConnection(): Promise<Connection> {
-    const { host, port } = this._connectionParams;
-    let addr = `${host}:${port}`;
-
-    const conn = await dial("tcp", addr);
-    const connection = new Connection(conn, this._connectionParams);
-
+    const connection = new Connection(this._connectionParams);
     await connection.startup();
     await connection.initSQL();
     return connection;
@@ -63,7 +57,7 @@ export class Pool {
   private async execute(query: Query): Promise<QueryResult> {
     await this._ready;
     const connection = await this._availableConnections.pop();
-    const result = await query.execute(connection);
+    const result = await connection.query(query);
     this._availableConnections.push(connection);
     return result;
   }

--- a/query.ts
+++ b/query.ts
@@ -86,8 +86,4 @@ export class Query {
     const encodingFn = config.encoder ? config.encoder : encode;
     return config.args.map(encodingFn);
   }
-
-  async execute(connection: Connection): Promise<QueryResult> {
-    return await connection.query(this);
-  }
 }


### PR DESCRIPTION
This means they can each be run independently.

fixes #10