### PR TITLE
Make QueryResult.rowDescription public

### DIFF
--- a/query.ts
+++ b/query.ts
@@ -12,7 +12,7 @@ export interface QueryConfig {
 }
 
 export class QueryResult {
-  private rowDescription: RowDescription;
+  public rowDescription: RowDescription;
   private _done = false;
   public rows: any[] = []; // actual results
 


### PR DESCRIPTION
Hello! Thanks for the lib 🙏 

Wondering if there was a reason QueryResult.rowDescription was private? Since the result rows come back to the caller in the form of an array, this info is particularly useful for mapping a single row result back into an object with column names for keys, a la:

```
export const mapResult = (result: QueryResult) =>
  result.rows.map(row =>
    row.reduce((record, column, index) => {
      const columnName = result.rowDescription.columns[index].name;
      return {
        ...record,
        [columnName]: column
      };
    })
  );
```